### PR TITLE
Add the possibility to read arguments from the command line when subm…

### DIFF
--- a/condor/runScoutingHistos_onCondor.sh
+++ b/condor/runScoutingHistos_onCondor.sh
@@ -16,8 +16,19 @@ usage()
 
 if [ -z $1 ]; then usage; fi
 
+str=" "
+i=1;
+for arg in "$@"
+do
+    if [ $i -gt 2 ]; then
+        str="$str $arg";
+    fi
+    i=$((i + 1));
+done
+
 export SCOUTINGINPUTDIR=$1
 export SCOUTINGOUTPUTDIR=$2
+export SCOUTINGARGS=$str
 export STARTDIR=$PWD
 
 mkdir -p condor/plotting_logs

--- a/condor/runScoutingHistos_onCondor.sub
+++ b/condor/runScoutingHistos_onCondor.sub
@@ -20,93 +20,93 @@ use_x509userproxy = True
 queue arguments from (
 ###
 ###DataB
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataB --splitIndex 0 --splitPace 1000000
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataB --splitIndex 0 --splitPace 1000000 $ENV(SCOUTINGARGS)
 ###DataC
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 0 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 1 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 2 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 3 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 4 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 5 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 6 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 7 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 8 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 9 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 10 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 11 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 12 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 13 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 14 --splitPace 1000000
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 0 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 1 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 2 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 3 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 4 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 5 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 6 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 7 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 8 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 9 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 10 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 11 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 12 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 13 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataC --splitIndex 14 --splitPace 1000000 $ENV(SCOUTINGARGS)
 ###DataD
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 0 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 1 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 2 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 3 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 4 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 5 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 6 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 7 --splitPace 1000000
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 0 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 1 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 2 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 3 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 4 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 5 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 6 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataD --splitIndex 7 --splitPace 1000000 $ENV(SCOUTINGARGS)
 ###DataE
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 0 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 1 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 2 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 3 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 4 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 5 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 6 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 7 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 8 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 9 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 10 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 11 --splitPace 1000000
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 0 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 1 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 2 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 3 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 4 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 5 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 6 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 7 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 8 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 9 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 10 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataE --splitIndex 11 --splitPace 1000000 $ENV(SCOUTINGARGS)
 ###DataF
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 0 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 1 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 2 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 3 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 4 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 5 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 6 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 7 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 8 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 9 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 10 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 11 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 12 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 13 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 14 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 15 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 16 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 17 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 18 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 19 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 20 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 21 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 22 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 23 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 24 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 25 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 26 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 27 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 28 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 29 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 30 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 31 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 32 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 33 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 34 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 35 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 36 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 37 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 38 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 39 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 40 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 41 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 42 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 43 --splitPace 1000000
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 0 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 1 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 2 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 3 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 4 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 5 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 6 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 7 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 8 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 9 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 10 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 11 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 12 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 13 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 14 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 15 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 16 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 17 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 18 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 19 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 20 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 21 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 22 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 23 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 24 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 25 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 26 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 27 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 28 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 29 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 30 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 31 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 32 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 33 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 34 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 35 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 36 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 37 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 38 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 39 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 40 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 41 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 42 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataF --splitIndex 43 --splitPace 1000000 $ENV(SCOUTINGARGS)
 ###DataG
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 0 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 1 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 2 --splitPace 1000000
-$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 3 --splitPace 1000000
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 0 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 1 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 2 --splitPace 1000000 $ENV(SCOUTINGARGS)
+$ENV(SCOUTINGINPUTDIR) $ENV(SCOUTINGOUTPUTDIR) --condor --data --inSample DataG --splitIndex 3 --splitPace 1000000 $ENV(SCOUTINGARGS)
 )


### PR DESCRIPTION
The PR modifies the sh and sub files to run the histogram filling on condor and it allows the arguments for `fillHistosScouting.py` to be passed as arguments of `runScoutingHistos_onCondor.sh`. 

The `runScoutingHistos_onCondor.sh` script processes the chain of additional arguments as an unique string which is further included in `runScoutingHistos_onCondor.sub`.