### PR TITLE
Update GT for 2023 end of data-taking

### DIFF
--- a/batch/Scouting/NtupleMaker/test/producer_Run3.py
+++ b/batch/Scouting/NtupleMaker/test/producer_Run3.py
@@ -46,7 +46,8 @@ if opts.data:
         #gtag="124X_dataRun3_Prompt_v4"
         #gtag="124X_dataRun3_HLT_v7" # latest HLT GT
     else:
-        gtag="130X_dataRun3_Prompt_frozen_v3" # latest prompt RECO GT (CMSSW>=13_0_10)
+        #gtag="130X_dataRun3_Prompt_frozen_v3" # latest prompt RECO GT (CMSSW>=13_0_10)
+        gtag="130X_dataRun3_Prompt_v4"
         #gtag="130X_dataRun3_HLT_frozen_v3" # latest HLT GT (CMSSW>=13_0_10)
 else:
     if '2022' in opts.era:


### PR DESCRIPTION
This is fix for the GT used in 2023. It was observed that RunD2023 had an unexpected small number of events, not compatible with reported luminosity. 
Problem was found to be the setting of the L1 prescales, that were fix to 0 for most of the events in this era. GT changed during 2023, this PR updates the GT to the last one used to process 2023 data. This GT was also checked to be compatible with early runs of 2023 e.g. or era 2023B, keeping the trigger conditions there.

For reference:
https://github.com/dmwm/T0/blob/afc8922522af4e6334dae2e38b577a468626fab5/etc/ProdOfflineConfiguration.py#L134

With 130X_dataRun3_Prompt_frozen_v3:
<img width="312" alt="Captura de pantalla 2024-05-22 a las 16 56 55" src="https://github.com/cmstas/run3_scouting/assets/29282388/53522cea-1d03-4b64-957c-60cf95a7bac6">

With 130X_dataRun3_Prompt_v4 (new):
<img width="316" alt="Captura de pantalla 2024-05-22 a las 16 57 09" src="https://github.com/cmstas/run3_scouting/assets/29282388/88b42fb0-b27a-4375-a7fa-fbabbdfc6de7">

